### PR TITLE
Feature/mm 368 Support for V2 Oauth Authentication - Self Client application

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ Or install it yourself as:
 
 ## Usage
 
-First we need an authentication token setup for requests:
+1. We will need to follow step 1,2,3 on zoho oAuth Authentication to get following set up:  
+2. From above step1 we will need a refresh token, client_id, client_secret, grant_type setup for requests for V2 Api:  
 
-    Zoro.auth_token = "SomeAuthToken"
+    Zoro.refresh_token = "SomeAuthToken"  
+    Zoro.client_id    = "YourClientId"
+    Zoro.client_secret = "YourClientSecret"
+    Zoro.grant_type   = "refresh_token"
 
 You can customize Faraday behavior for logging or other things by replacing the Zoro connection. I'll probably change this down stream to allow more configurable.
 

--- a/examples/add_lead.rb
+++ b/examples/add_lead.rb
@@ -1,6 +1,9 @@
 require 'zoro'
-
-Zoro.auth_token = 'some-valid-auth-token'
+# please refer the ReadMe file to get some more info on those values.
+Zoro.refresh_token = 'some-valid-auth-token'
+Zoro.client_id = 'some-valid-client-id'
+Zoro.client_secret = 'some-valid-client-secret'
+Zoro.grant_type = 'refresh_token'
 Zoro.http_connection = Faraday::Connection.new do |conn|
   conn.request :url_encoded
   conn.response :logger #Log Faraday to STDOUT for easier testing

--- a/lib/zoro.rb
+++ b/lib/zoro.rb
@@ -7,11 +7,16 @@ require 'zoro/field_name'
 require 'faraday'
 require 'xmlsimple'
 
+
 module Zoro
   extend self
-  attr_accessor :auth_token, :http_connection
+  attr_accessor :refresh_token, :http_connection, :client_id, :client_secret, :grant_type
 
   def http_connection
     @http_connection ||= Faraday::Connection.new
+  end
+  
+  def grant_type
+    @grant_type ||= "refresh_token"
   end
 end

--- a/lib/zoro/api.rb
+++ b/lib/zoro/api.rb
@@ -1,4 +1,6 @@
 require 'faraday'
+require 'uri'
+
 
 module Zoro
   class Api
@@ -6,13 +8,31 @@ module Zoro
       "https://www.zohoapis.com/crm/v2/#{mod}"
     end
 
+    def get_auth_token
+      refresh_token_url= "https://accounts.zoho.com/oauth/v2/token"
+      data = {  :refresh_token => Zoro.refresh_token, :grant_type => Zoro.grant_type, 
+                :client_id => Zoro.client_id , :client_secret => Zoro.client_secret 
+             }
+      
+      response = Zoro.http_connection.post do |req|
+        req.headers['Content-Type'] = "application/x-www-form-urlencoded"
+        req.url token_url
+        req.body = URI.encode_www_form(data)
+      end
+      
+      response_obj = JSON.parse(response.body) 
+      Zoro.refresh_token = "Zoho-oauthtoken #{response_obj["access_token"]}" if response_obj.has_key?('access_token')
+    
+    end
+    
     def insert_records(record)
       url = format_url(record.zoho_module, "") # v2 no longer needs the insertRecords
       data = { data: [record] }.to_json()
 
       Zoro.http_connection.post do |req|
         req.url url
-        req.headers['Authorization'] = Zoro.auth_token
+        req.headers['Authorization'] = get_auth_token
+        req.headers['Content-Type'] = 'application/json'
         req.body = data
       end
     end

--- a/lib/zoro/version.rb
+++ b/lib/zoro/version.rb
@@ -1,3 +1,3 @@
 module Zoro
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/test/zoro/api_test.rb
+++ b/test/zoro/api_test.rb
@@ -3,7 +3,7 @@ require 'zoro/api'
 
 describe Zoro::Api do
   it "can format the URL to insert lead records" do
-    Zoro.auth_token = "1234"
+    Zoro.refresh_token = "1234"
     api = Zoro::Api.new
     url = api.format_url("Leads", "insertRecords")
     url.must_equal "https://crm.zoho.com/crm/private/xml/Leads/insertRecords"
@@ -11,7 +11,7 @@ describe Zoro::Api do
 
   it "can insert records into the zoro CRM" do
     #Stub HTTP
-    Zoro.auth_token = "1234"
+    Zoro.refresh_token = "1234"
     stubs = stub_http
     stubs.get("/crm/private/xml/Leads/insertRecords") {[200, {}, 'foo']}
 

--- a/zoro.gemspec
+++ b/zoro.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('mocha')
   gem.add_dependency('faraday')
   gem.add_dependency('xml-simple')
+  gem.add_dependency('uri')
 end


### PR DESCRIPTION
Feature/mm 368 Support for V2 Oauth Authentication - Self Client application.

- Added  and renamed gem configurable variables. 
- Utilized the refresh_token to get the new access token with each API requests ( not planning to manage the expired access token)
