### PR TITLE
Feature/mm 414 Fix to Provide correct return value for auth token

### DIFF
--- a/lib/zoro/api.rb
+++ b/lib/zoro/api.rb
@@ -21,7 +21,7 @@ module Zoro
       end
       
       response_obj = JSON.parse(response.body) 
-      Zoro.refresh_token = "Zoho-oauthtoken #{response_obj["access_token"]}" if response_obj.has_key?('access_token')
+      auth_token = "Zoho-oauthtoken #{response_obj["access_token"]}" if response_obj.has_key?('access_token')
     
     end
     

--- a/lib/zoro/version.rb
+++ b/lib/zoro/version.rb
@@ -1,3 +1,3 @@
 module Zoro
-  VERSION = "0.2.0"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
Feature/mm 414 Fix to Provide correct return value for auth token

With the previous code, due to a typo, refresh_token was being overwritten after initial call